### PR TITLE
Support check response content

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -56,7 +56,7 @@ class TestValidatorValidation(TestCase):
                 'http://example.com',
                 status_code=200,
                 headers={'x-test': 'foobar'},
-                content=["script"],
+                content={'present': ['script'], 'absent': ['meta']},
             )])
 
     def assertRuleMatches(self, result, passing=True, error=None):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -55,7 +55,8 @@ class TestValidatorValidation(TestCase):
             ValidatorSpecRule(
                 'http://example.com',
                 status_code=200,
-                headers={'x-test': 'foobar'}
+                headers={'x-test': 'foobar'},
+                content=["script"],
             )])
 
     def assertRuleMatches(self, result, passing=True, error=None):
@@ -71,6 +72,7 @@ class TestValidatorValidation(TestCase):
         '''Vanilla response with headers matches rule'''
         mock.return_value = Response()
         mock.return_value.status_code = 200
+        mock.return_value._content = b"Page source containing 'script' word."
         mock.return_value.headers = {'x-test': 'foobar'}
         for result in self.validator.validate():
             self.assertRuleMatches(result, passing=True)

--- a/validatehttp/spec.py
+++ b/validatehttp/spec.py
@@ -150,10 +150,6 @@ class ValidatorSpecRule(object):
                                 mismatch=(value, resp_value),
                             )
                 elif key == 'content':
-                    if not resp.ok:
-                        # Response was not OK. Ignoring content check.
-                        continue
-
                     for (status, contents) in params.get('content').items():
                         for value in contents:
                             if status == 'present' and value not in resp.text:

--- a/validatehttp/spec.py
+++ b/validatehttp/spec.py
@@ -158,11 +158,11 @@ class ValidatorSpecRule(object):
                         for value in contents:
                             if status == 'present' and value not in resp.text:
                                 raise ValidationError(
-                                    'Response content not found: {0}'.format(value),
+                                    'Response content absent: {0}'.format(value),
                                 )
                             if status == 'absent' and value in resp.text:
                                 raise ValidationError(
-                                    'Response content not found: {0}'.format(value),
+                                    'Response content present: {0}'.format(value),
                                 )
 
                 else:

--- a/validatehttp/spec.py
+++ b/validatehttp/spec.py
@@ -149,6 +149,16 @@ class ValidatorSpecRule(object):
                                 'Response header mismatch: {0}'.format(header),
                                 mismatch=(value, resp_value),
                             )
+                elif key == 'content':
+                    if not resp.ok:
+                        # Response was not OK. Ignoring content check.
+                        continue
+
+                    for value in params.get('content'):
+                        if value not in resp.text:
+                            raise ValidationError(
+                                'Response content not found: {0}'.format(value),
+                            )
                 else:
                     resp_value = getattr(resp, key, None)
                     if resp_value != value:

--- a/validatehttp/spec.py
+++ b/validatehttp/spec.py
@@ -154,11 +154,17 @@ class ValidatorSpecRule(object):
                         # Response was not OK. Ignoring content check.
                         continue
 
-                    for value in params.get('content'):
-                        if value not in resp.text:
-                            raise ValidationError(
-                                'Response content not found: {0}'.format(value),
-                            )
+                    for (status, contents) in params.get('content').items():
+                        for value in contents:
+                            if status == 'present' and value not in resp.text:
+                                raise ValidationError(
+                                    'Response content not found: {0}'.format(value),
+                                )
+                            if status == 'absent' and value in resp.text:
+                                raise ValidationError(
+                                    'Response content not found: {0}'.format(value),
+                                )
+
                 else:
                     resp_value = getattr(resp, key, None)
                     if resp_value != value:


### PR DESCRIPTION
Use the following to check for content:

```yaml
https://docs.readthedocs.io/en/stable/:
  content:
    - '<sript src="/_/static/javascript/readthedocs-analytics.js"></script>'
    - '<meta property="og:title" content="Read the Docs: documentation simplified" />'
```

The response has to be return successfully to perform the check, otherwise, it's ignored. There are some improvements we could add here, but I think it's a good start for our use case: "check if the addons has been injected"

Related https://github.com/readthedocs/readthedocs-ops/issues/1442