### PR TITLE
Fix verbose reporting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='validatehttp',
-    version=0.1,
+    version=0.2,
     description='Validate a list of HTTP request spec against a host',
     long_description=__doc__,
     keywords='nagios url',

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -65,7 +65,7 @@ class TestValidatorValidation(TestCase):
         else:
             self.assertIsInstance(result, ValidationFail)
         if error is not None:
-            self.assertRegexpMatches(str(result.error), error)
+            self.assertRegex(str(result.error), error)
 
     @patch('validatehttp.validate.Session.send')
     def test_response_match(self, mock):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,lint,docs
+envlist = py312,docs
 
 [testenv]
 setenv =
@@ -8,7 +8,9 @@ deps =
     pytest
     mock
 commands =
-    py.test {posargs}
+    py.test {posargs} tests/
+basepython =
+    python3.12
 
 [testenv:docs]
 changedir = {toxinidir}/docs
@@ -16,14 +18,3 @@ deps =
     Sphinx
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
-
-[testenv:lint]
-deps =
-    {[testenv]deps}
-    pylint
-    prospector
-commands =
-    prospector \
-    --profile-path={toxinidir} \
-    --profile=prospector \
-    --die-on-tool-error

--- a/validatehttp/cli.py
+++ b/validatehttp/cli.py
@@ -39,8 +39,6 @@ class ValidatorCLI(object):
                     extra = (' ' * 4) + str(result.error)
                     try:
                         (expected, received) = result.mismatch()
-                        if isinstance(received, str):
-                            received = received.decode('utf-8')
                         extra += u'\n'.join([
                             u'',
                             (u' ' * 8) + u'Expected: {0}'.format(expected),


### PR DESCRIPTION
There have been no verbose outputs due to Python 3 and later changes to
string and utf8 handling.

Dropping linting because prospector. Will replace this with ruff.